### PR TITLE
Add Search Console API test site template

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,2 @@
+<!doctype html><html lang="ja"><head><meta charset="utf-8" />
+<title>404</title></head><body><h1>Not Found</h1></body></html>

--- a/blocked/page.html
+++ b/blocked/page.html
@@ -1,0 +1,2 @@
+<!doctype html><html lang="ja"><head><meta charset="utf-8" />
+<title>Blocked</title></head><body><h1>Blocked by robots.txt</h1></body></html>

--- a/canonical.html
+++ b/canonical.html
@@ -1,0 +1,4 @@
+<!doctype html><html lang="ja"><head><meta charset="utf-8" />
+<title>Canonical Copy</title>
+<link rel="canonical" href="https://<your-user>.github.io/search-console-test/original.html" />
+</head><body><h1>Canonical Copy</h1></body></html>

--- a/en/index.html
+++ b/en/index.html
@@ -1,0 +1,4 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8" />
+<title>English</title>
+<link rel="alternate" hreflang="ja" href="https://<your-user>.github.io/search-console-test/ja/" />
+</head><body><h1>English page</h1></body></html>

--- a/index.html
+++ b/index.html
@@ -1,2 +1,13 @@
-<!doctype html><html lang="ja"><head><meta charset="utf-8"><title>My Page</title></head>
-<body><h1>Hello GitHub Pages</h1></body></html>
+<!doctype html><html lang="ja"><head>
+<meta charset="utf-8" />
+<title>GSC API Test</title>
+<!-- Search Console のメタタグ検証をここに貼る -->
+<!-- 例: <meta name="google-site-verification" content="xxxxxxx" /> -->
+<link rel="canonical" href="https://<your-user>.github.io/search-console-test/" />
+<link rel="alternate" hreflang="ja" href="https://<your-user>.github.io/search-console-test/ja/"/>
+<link rel="alternate" hreflang="en" href="https://<your-user>.github.io/search-console-test/en/"/>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+</head><body>
+<h1>GSC API Test Home</h1>
+<p>Search Console API 検証用の最小サイト。</p>
+</body></html>

--- a/ja/index.html
+++ b/ja/index.html
@@ -1,0 +1,4 @@
+<!doctype html><html lang="ja"><head><meta charset="utf-8" />
+<title>日本語版</title>
+<link rel="alternate" hreflang="en" href="https://<your-user>.github.io/search-console-test/en/" />
+</head><body><h1>日本語ページ</h1></body></html>

--- a/noindex.html
+++ b/noindex.html
@@ -1,0 +1,5 @@
+<!doctype html><html lang="ja"><head>
+<meta charset="utf-8" />
+<title>Noindex Page</title>
+<meta name="robots" content="noindex,nofollow" />
+</head><body><h1>Noindex</h1></body></html>

--- a/original.html
+++ b/original.html
@@ -1,0 +1,2 @@
+<!doctype html><html lang="ja"><head><meta charset="utf-8" />
+<title>Original</title></head><body><h1>Original</h1></body></html>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Disallow: /blocked/
+Sitemap: https://<your-user>.github.io/search-console-test/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://<your-user>.github.io/search-console-test/</loc></url>
+  <url><loc>https://<your-user>.github.io/search-console-test/noindex.html</loc></url>
+  <url><loc>https://<your-user>.github.io/search-console-test/original.html</loc></url>
+  <url><loc>https://<your-user>.github.io/search-console-test/canonical.html</loc></url>
+  <url><loc>https://<your-user>.github.io/search-console-test/ja/</loc></url>
+  <url><loc>https://<your-user>.github.io/search-console-test/en/</loc></url>
+  <url><loc>https://<your-user>.github.io/search-console-test/blocked/page.html</loc></url>
+</urlset>

--- a/sitemap_index.xml
+++ b/sitemap_index.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+    <loc>https://<your-user>.github.io/search-console-test/sitemaps/base.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://<your-user>.github.io/search-console-test/sitemaps/blog.xml</loc>
+  </sitemap>
+</sitemapindex>

--- a/sitemaps/base.xml
+++ b/sitemaps/base.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://<your-user>.github.io/search-console-test/</loc></url>
+  <url><loc>https://<your-user>.github.io/search-console-test/original.html</loc></url>
+</urlset>

--- a/sitemaps/blog.xml
+++ b/sitemaps/blog.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://<your-user>.github.io/search-console-test/ja/</loc></url>
+  <url><loc>https://<your-user>.github.io/search-console-test/en/</loc></url>
+</urlset>


### PR DESCRIPTION
## Summary
- scaffold minimal GitHub Pages site for Search Console API demos
- include pages for noindex, canonical, hreflang, robots blocking, and 404 tests
- add sitemaps and sitemap index for API verification

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b65b54ab80832fa39d5f5ce50d3879