### PR TITLE
Add international landing page with hreflang alternates

### DIFF
--- a/intl/index.html
+++ b/intl/index.html
@@ -1,0 +1,6 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8" />
+<title>International</title>
+<link rel="alternate" hreflang="x-default" href="https://<your-user>.github.io/search-console-test/intl/" />
+<link rel="alternate" hreflang="ja" href="https://<your-user>.github.io/search-console-test/ja/" />
+<link rel="alternate" hreflang="en" href="https://<your-user>.github.io/search-console-test/en/" />
+</head><body><h1>International page</h1><a href="../ja/">日本語</a> <a href="../en/">English</a></body></html>


### PR DESCRIPTION
## Summary
- add `intl/index.html` with `hreflang` alternate links for x-default, Japanese, and English
- include links to local `ja` and `en` pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6612fb738832fb75c9baf4f8603af