### PR TITLE
Add structured data HTML examples

### DIFF
--- a/structured/article.html
+++ b/structured/article.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>Article structured data</title>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Example Article",
+  "author": {
+    "@type": "Person",
+    "name": "Jane Doe"
+  },
+  "datePublished": "2025-09-01"
+}
+</script>
+</head>
+<body>
+<h1>Article structured data</h1>
+</body>
+</html>

--- a/structured/breadcrumb.html
+++ b/structured/breadcrumb.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>Breadcrumb structured data</title>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://github.com/kou12345/search-console-test"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Breadcrumb",
+      "item": "https://github.com/kou12345/search-console-test/structured/breadcrumb.html"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+<h1>Breadcrumb structured data</h1>
+</body>
+</html>

--- a/structured/faq.html
+++ b/structured/faq.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>FAQ structured data</title>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is this site?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "It demonstrates Search Console structured data."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How do I use it?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Inspect pages using Search Console to see structured data."
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+<h1>FAQ structured data</h1>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add sample Article, FAQ and Breadcrumb pages under `structured/`
- embed JSON-LD snippets for each structured data type
- use actual repository URL in breadcrumb item links

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6612f6914832fb203088e528b20c5