### PR TITLE
Add structured and pagination sitemaps

### DIFF
--- a/sitemap_index.xml
+++ b/sitemap_index.xml
@@ -1,9 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <sitemap>
-    <loc>https://<your-user>.github.io/search-console-test/sitemaps/base.xml</loc>
+    <loc>https://kou12345.github.io/search-console-test/sitemaps/base.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://<your-user>.github.io/search-console-test/sitemaps/blog.xml</loc>
+    <loc>https://kou12345.github.io/search-console-test/sitemaps/blog.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://kou12345.github.io/search-console-test/sitemaps/structured.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://kou12345.github.io/search-console-test/sitemaps/pagination.xml</loc>
   </sitemap>
 </sitemapindex>


### PR DESCRIPTION
## Summary
- add links to structured and pagination sitemaps in `sitemap_index.xml`
- replace placeholders with repository's actual URL

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/search-console-test/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b66132bb94832f985772551093a2df