### PR TITLE
Add structured and pagination sitemaps

### DIFF
--- a/pagination/page1.html
+++ b/pagination/page1.html
@@ -1,5 +1,4 @@
-<!doctype html><html lang="ja"><head>
-<meta charset="utf-8" />
+<!doctype html><html lang="ja"><head><meta charset="utf-8" />
 <title>Pagination Page 1</title>
 <link rel="next" href="https://<your-user>.github.io/search-console-test/pagination/page2.html" />
 </head><body><h1>Pagination Page 1</h1></body></html>

--- a/pagination/page1.html
+++ b/pagination/page1.html
@@ -1,0 +1,5 @@
+<!doctype html><html lang="ja"><head>
+<meta charset="utf-8" />
+<title>Pagination Page 1</title>
+<link rel="next" href="https://<your-user>.github.io/search-console-test/pagination/page2.html" />
+</head><body><h1>Pagination Page 1</h1></body></html>

--- a/pagination/page2.html
+++ b/pagination/page2.html
@@ -1,0 +1,5 @@
+<!doctype html><html lang="ja"><head>
+<meta charset="utf-8" />
+<title>Pagination Page 2</title>
+<link rel="prev" href="https://<your-user>.github.io/search-console-test/pagination/page1.html" />
+</head><body><h1>Pagination Page 2</h1></body></html>

--- a/pagination/page2.html
+++ b/pagination/page2.html
@@ -1,5 +1,4 @@
-<!doctype html><html lang="ja"><head>
-<meta charset="utf-8" />
+<!doctype html><html lang="ja"><head><meta charset="utf-8" />
 <title>Pagination Page 2</title>
 <link rel="prev" href="https://<your-user>.github.io/search-console-test/pagination/page1.html" />
 </head><body><h1>Pagination Page 2</h1></body></html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -7,4 +7,7 @@
   <url><loc>https://<your-user>.github.io/search-console-test/ja/</loc></url>
   <url><loc>https://<your-user>.github.io/search-console-test/en/</loc></url>
   <url><loc>https://<your-user>.github.io/search-console-test/blocked/page.html</loc></url>
+  <url><loc>https://<your-user>.github.io/search-console-test/structured.html</loc></url>
+  <url><loc>https://<your-user>.github.io/search-console-test/pagination/page1.html</loc></url>
+  <url><loc>https://<your-user>.github.io/search-console-test/pagination/page2.html</loc></url>
 </urlset>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -7,7 +7,4 @@
   <url><loc>https://<your-user>.github.io/search-console-test/ja/</loc></url>
   <url><loc>https://<your-user>.github.io/search-console-test/en/</loc></url>
   <url><loc>https://<your-user>.github.io/search-console-test/blocked/page.html</loc></url>
-  <url><loc>https://<your-user>.github.io/search-console-test/structured.html</loc></url>
-  <url><loc>https://<your-user>.github.io/search-console-test/pagination/page1.html</loc></url>
-  <url><loc>https://<your-user>.github.io/search-console-test/pagination/page2.html</loc></url>
 </urlset>

--- a/sitemap_index.xml
+++ b/sitemap_index.xml
@@ -6,4 +6,10 @@
   <sitemap>
     <loc>https://<your-user>.github.io/search-console-test/sitemaps/blog.xml</loc>
   </sitemap>
+  <sitemap>
+    <loc>https://<your-user>.github.io/search-console-test/sitemaps/structured.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://<your-user>.github.io/search-console-test/sitemaps/pagination.xml</loc>
+  </sitemap>
 </sitemapindex>

--- a/sitemap_index.xml
+++ b/sitemap_index.xml
@@ -7,9 +7,9 @@
     <loc>https://<your-user>.github.io/search-console-test/sitemaps/blog.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://<your-user>.github.io/search-console-test/sitemaps/structured.xml</loc>
+    <loc>https://<your-user>.github.io/search-console-test/sitemaps/pagination.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://<your-user>.github.io/search-console-test/sitemaps/pagination.xml</loc>
+    <loc>https://<your-user>.github.io/search-console-test/sitemaps/structured.xml</loc>
   </sitemap>
 </sitemapindex>

--- a/sitemaps/pagination.xml
+++ b/sitemaps/pagination.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://<your-user>.github.io/search-console-test/pagination/page1.html</loc></url>
+  <url><loc>https://<your-user>.github.io/search-console-test/pagination/page2.html</loc></url>
+</urlset>

--- a/sitemaps/structured.xml
+++ b/sitemaps/structured.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://<your-user>.github.io/search-console-test/structured.html</loc></url>
+</urlset>

--- a/structured.html
+++ b/structured.html
@@ -1,0 +1,11 @@
+<!doctype html><html lang="ja"><head>
+<meta charset="utf-8" />
+<title>Structured Data</title>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "name": "Structured Data"
+}
+</script>
+</head><body><h1>Structured Data Page</h1></body></html>


### PR DESCRIPTION
## Summary
- add structured data page and pagination demo pages
- provide dedicated sitemaps for structured data and pagination pages
- register new sitemaps in sitemap index and root sitemap

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b66131f2f8832f98ac3b26ecab42bb